### PR TITLE
Fix: Uncaught ReferenceError: ProtocolError is not defined

### DIFF
--- a/dist/livereload.js
+++ b/dist/livereload.js
@@ -47,7 +47,7 @@ __protocol.Parser = Parser = (function() {
       }
     } catch (_error) {
       e = _error;
-      if (e instanceof ProtocolError) {
+        if (typeof ProtocolError != 'undefined' && e instanceof ProtocolError) {
         return this.handlers.error(e);
       } else {
         throw e;
@@ -963,7 +963,7 @@ __livereload.LiveReload = LiveReload = (function() {
       })(this),
       error: (function(_this) {
         return function(e) {
-          if (e instanceof ProtocolError) {
+            if (typeof ProtocolError != 'undefined' && e instanceof ProtocolError) {
             return _this.log("" + e.message + ".");
           } else {
             return _this.log("LiveReload internal error: " + e.message);


### PR DESCRIPTION
Sometimes, and for no particular reason I can determine, LiveReload-js throws a wobbly and spams the dev console with errors.

![image](https://cloud.githubusercontent.com/assets/100964/25040009/89c96830-210f-11e7-8edb-e51681371708.png)

This should fix the issue.